### PR TITLE
Added Ender 3 V2 DWIN Support for the Makerbase MKS Robin E3P board

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -511,6 +511,8 @@
   #ifndef LCD_SERIAL_PORT
     #if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_MINI_E3_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO)
       #define LCD_SERIAL_PORT 1
+    #elif MB(MKS_ROBIN_E3P)
+      #define LCD_SERIAL_PORT 2
     #else
       #define LCD_SERIAL_PORT 3 // Creality 4.x board
     #endif

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -363,6 +363,33 @@
   #define BEEPER_PIN                        PC5
 #endif
 
+#if EITHER(HAS_DWIN_E3V2, IS_DWIN_MARLINUI)
+
+/**
+ *        ------
+ *       |12  11|               ------                ------
+ *   ENT |10  9 | A            |10  9 |              |10  9 |
+ *    TX | 8  7 | RX      (RX) | 8  7 | (TX)      RX | 8  7 | TX
+ *  BEEP | 6  5 | B      (ENT)   6  5 | (BEEP)  ENT || 6  5 | BEEP
+ *   GND | 4  3 |          (B) | 4  3 | (A)        B | 4  3 | A
+ *   VCC | 2  1 |          GND | 2  1 | VCC      GND | 2  1 | VCC
+ *        ------                ------                ------
+ *        EXT-IO                  DWIN               DWIN (plug)
+ *
+ * All pins are labeled as printed on DWIN PCB. Connect TX-TX, A-A and so on.
+ */
+
+  //#error "Ender-3 V2 display requires a custom cable, see diagram above this line. Comment out this line to continue."
+
+  #define BTN_ENC                           PA1
+  #define BTN_EN1                           PC2
+  #define BTN_EN2                           PB0
+
+  #ifndef BEEPER_PIN
+    #define BEEPER_PIN                      PE7
+  #endif
+#endif
+
 #if ENABLED(SPEAKER) && BEEPER_PIN == PC5
   #error "MKS Robin nano default BEEPER_PIN is not a SPEAKER."
 #endif


### PR DESCRIPTION
### Description

<!--

Adds support for the Ender 3 v2 DWIN display to the MKS Robin E3P board via the exposed USART2 on the Ext IO header. This is done similar to the support on the SKR E3.
-->

### Requirements

- MKS E3P
- ENDER 3 v2 DWIN Display
- free EXT IO Header on the board
- Custom Display cable (included wiring instructions)

### Benefits

Adds support for the standard E3 v2 display to the board.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
